### PR TITLE
feat(dynamic-import): Dynamic import hook modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/plugin-hooks",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publishConfig": {
     "access": "public"
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,11 +56,13 @@ const __importStar =
   function (mod) {
     if (mod && mod.__esModule) return mod;
     const result = {};
-    if (mod != null)
-      for (const k in mod)
+    if (mod != null) {
+      for (const k in mod) {
         if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k))
           __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
+      }
+      __setModuleDefault(result, mod.default);
+    }
     return result;
   };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,8 +58,9 @@ const __importStar =
     const result = {};
     if (mod != null) {
       for (const k in mod) {
-        if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k))
+        if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) {
           __createBinding(result, mod, k);
+        }
       }
       __setModuleDefault(result, mod.default);
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,7 +65,7 @@ const __importStar =
   };
 
 function importFn(modulePath) {
-  return Promise.resolve().then(() => __importStar(require(modulePath)));
+  return Promise.resolve(import(modulePath)).then((module) => __importStar(module));
 }
 
 /** Test code end */


### PR DESCRIPTION
## Description

Updated to dynamic import as part of changes to support edge compatibility of hooks.

## Related Issue

CEXT-2904

## Motivation and Context

Previous the package was using dynamic require to import and compose hook functions, which is not compatible with edge runtime. 

## How Has This Been Tested?

- Link to aio plugin for local development.
- Link to mesh builder.
- Link to legacy api mesh.
- Link to edge api mesh.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.