### PR TITLE
feat(support-local-hooks-edge): CEXT-2904 - Updated code to make newrelic agent optional.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/plugin-hooks",
-  "version": "0.3.2",
+  "version": "0.3.2-beta",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/plugin-hooks",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publishConfig": {
     "access": "public"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,8 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-const newrelic = require("newrelic");
+const agent = require('./telemetry/register');
+
 const handleBeforeAllHooks = require("./handleBeforeAllHooks");
 
 async function hooksPlugin(config) {
@@ -34,7 +35,7 @@ async function hooksPlugin(config) {
 
     return {
       async onExecute({ args, setResultAndStopExecution, extendContext }) {
-        await newrelic.startSegment('handleBeforeAllHooks:onExecute', true, async() => {
+        await agent.startSegment('handleBeforeAllHooks:onExecute', true, async() => {
           
          
         const query = args.contextValue.params.query;

--- a/src/telemetry/agents/log.js
+++ b/src/telemetry/agents/log.js
@@ -1,0 +1,15 @@
+/**
+ * Stub replacement for newrelic.startSegment used by `plugin-hooks`. Does NOT report telemetry back to newrelic.
+ * @param {string} name The name to give the new segment. This will also be the name of the metric.
+ * @param {boolean} record Indicates if the segment should be recorded as a metric. Metrics will show up on the transaction breakdown table and server breakdown graph. Segments just show up in transaction traces.
+ * @param {() => Promise<void>}handler The function to track as a segment.
+ * @param {Function?} _callback An optional callback for the handler. This will indicate the end of the timing if provided.
+ */
+const startSegment = async (name, record, handler, _callback) => {
+	console.log(name);
+	await handler();
+}
+
+module.exports = {
+	startSegment,
+}

--- a/src/telemetry/register.js
+++ b/src/telemetry/register.js
@@ -1,0 +1,16 @@
+let agent;
+
+// Attempt to register newrelic agent
+try {
+	agent = require("newrelic");
+} catch (err) {
+	console.warn('newrelic agent not installed...');
+}
+
+// No other telemetry agents were registered so fall back on logging
+if (!agent) {
+	console.log('Falling back on log agent...');
+	agent = require('./agents/log');
+}
+
+module.exports = agent;


### PR DESCRIPTION
## Description

Wrap newrelic agent usage in an barebones abstraction of a telemetry agent. Implemented a log agent as fallback.

## Related Issue

CEXT-2904

## Motivation and Context

Existing code required newrelic as a dependency which forced opinions on consumers.

## How Has This Been Tested?

- Linked to mesh builder.
- Linked to legacy api mesh.
- Linked to edge mesh.
- Linked to sms.

Include plugin in projects that do not have newrelic as a dependency. Mesh should build and function without error.
Include plugin in projects that do have newrelic as a dependency. Mesh should build and function without error, sending telemetry to newrelic when application is configured to do so.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.