### PR TITLE
Fix/cext 4399 localdev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/plugin-hooks",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "publishConfig": {
     "access": "public"
   },

--- a/src/handleBeforeAllHooks.js
+++ b/src/handleBeforeAllHooks.js
@@ -11,27 +11,40 @@ governing permissions and limitations under the License.
 */
 
 const {
+  importFn,
+  isModuleFn,
   isRemoteFn,
   invokeLocalFunction,
+  invokeLocalModuleFunction,
   invokeRemoteFunction,
-  importFn,
 } = require("./utils");
 
 const handleBeforeAllHooks = (fnBuildConfig) => async (fnExecConfig) => {
   try {
     const { memoizedFns, baseDir, logger, beforeAll } = fnBuildConfig;
     const { payload, updateContext } = fnExecConfig;
-    let beforeAllFn = null;
+    let beforeAllFn;
 
     if (!memoizedFns.beforeAll) {
       if (isRemoteFn(beforeAll.composer)) {
+        // Invoke remote endpoint
         beforeAllFn = await invokeRemoteFunction(beforeAll.composer, {
           baseDir,
           importFn,
           logger,
           blocking: beforeAll.blocking,
         });
+      } else if (isModuleFn(beforeAll)) {
+        // Invoke function from imported module. This handles bundled scenarios such as local development where the
+        // module needs to be known statically at build time.
+        beforeAllFn = await invokeLocalModuleFunction(beforeAll.module, beforeAll.fn, {
+          baseDir,
+          importFn,
+          logger,
+          blocking: beforeAll.blocking,
+        });
       } else {
+        // Invoke local function at runtime
         beforeAllFn = await invokeLocalFunction(beforeAll.composer, {
           baseDir,
           importFn,

--- a/src/utils.js
+++ b/src/utils.js
@@ -172,6 +172,100 @@ const invokeRemoteFunction = async (url, metaConfig) => (data) => {
   }
 };
 
+/**
+ * Invoke local module function. Used in situations where the module needs to be imported at build time such as in
+ * bundled use cases like local development.
+ * @param mod Imported/required JavaScript module.
+ * @param functionName Function name.
+ * @param metaConfig Meta configuration
+ * @returns {Promise<function(*): Promise<unknown>>}
+ */
+const invokeLocalModuleFunction = async (mod, functionName, metaConfig) => {
+  const { logger, blocking } = metaConfig;
+
+  const exportName = functionName || 'default'
+
+  let composerFn = null;
+
+  try {
+    composerFn = mod[exportName] || (mod.default && mod.default[exportName]) || mod.default || mod;
+  } catch (err) {
+    logger.error("error while invoking local function %s", composerFn);
+    logger.error(err);
+
+    return Promise.reject({
+      status: "ERROR",
+      message:
+        err.message || `Unable to invoke local function ${composerFn}`,
+    });
+  }
+
+  return (data) => {
+    return new Promise((resolve, reject) => {
+      try {
+        if (!composerFn) {
+          reject({
+            status: "ERROR",
+            message: `Unable to invoke local function ${composerFn}`,
+          });
+        }
+
+        logger.debug("Invoking local fn %o", composerFn);
+
+        const result = composerFn(data);
+
+        if (blocking) {
+          if (result instanceof Promise) {
+            timedPromise(result)
+              .then((res) => {
+                if (res.status.toUpperCase() === "SUCCESS") {
+                  resolve(res);
+                } else {
+                  reject(res);
+                }
+              })
+              .catch((error) => {
+                logger.error(
+                  "error while invoking local function %o",
+                  composerFn
+                );
+                logger.error(error);
+
+                reject({
+                  status: "ERROR",
+                  message:
+                    error.message ||
+                    `Error while invoking local function ${composerFn}`,
+                });
+              });
+          } else {
+            if (result.status.toUpperCase() === "SUCCESS") {
+              resolve(result);
+            } else {
+              reject(result);
+            }
+          }
+        } else {
+          resolve({
+            status: "SUCCESS",
+            message: "Local function invoked successfully",
+          });
+        }
+      } catch (error) {
+        logger.error("error while invoking local function %o", composerFn);
+        logger.error(error);
+
+        reject({
+          status: "ERROR",
+          message:
+            error.message ||
+            `Error while invoking local function ${composerFn}`,
+        });
+      }
+    });
+  };
+};
+
 const invokeLocalFunction = async (composerFnPath, metaConfig) => {
   const { baseDir, logger, importFn, blocking } = metaConfig;
 
@@ -267,9 +361,20 @@ const isRemoteFn = (composer) => {
   return urlRegex.test(composer);
 };
 
+/**
+ * Whether beforeAll has module reference.
+ * @param beforeAll
+ * @returns {boolean}
+ */
+const isModuleFn = (beforeAll) => {
+  return !!(beforeAll.module && beforeAll.fn);
+}
+
 module.exports = {
   invokeRemoteFunction,
+  invokeLocalModuleFunction,
   invokeLocalFunction,
   isRemoteFn,
+  isModuleFn,
   importFn,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Local development for edge is unable to handle hooks because they are resolved at runtime. Added a new type of configuration and signature allowing for static modules to be imported and then passed into plugin hooks.

## Related Issue

CEXT-4399

## Motivation and Context

Produces a better user experience for local development where users may debug hook files from their project.

## How Has This Been Tested?

- `yarn link` to aio-cli-plugin-api-mesh

## Screenshots (if appropriate):

Example generated js config that would access this new branch:
![image](https://github.com/user-attachments/assets/f3bfe34f-e1ac-4733-bc0d-bb7d984b6a93)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.