### PR TITLE
chore: added dynamicImport.js to handle the commonJs case (failing on node v.18 inside docker)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/plugin-hooks",
-  "version": "0.3.5-alpha.1",
+  "version": "0.3.5-alpha.2",
   "publishConfig": {
     "access": "public"
   },
@@ -23,7 +23,7 @@
     "build": "yarn clean && yarn build:esm && yarn build:cjs && yarn copy:js",
     "build:esm": "tsc --project tsconfig.esm.json --outDir dist/esm",
     "build:cjs": "tsc --project tsconfig.cjs.json --outDir dist/cjs",
-    "copy:js": "cp src/dynamicImport.js dist/esm/ && cp src/dynamicImport.js dist/cjs/",
+    "copy:js": "cp src/dynamicImport.js dist/esm/ && cp src/dynamicImport.cjs dist/cjs/dynamicImport.js",
     "prepack": "yarn build",
     "lint": "eslint src",
     "lint:fix": "eslint --fix .",

--- a/src/dynamicImport.cjs
+++ b/src/dynamicImport.cjs
@@ -1,0 +1,21 @@
+/**
+ * CommonJS version of dynamic import function.
+ * 
+ * This file exists to support dual module formats (CommonJS + ES modules) in the plugin-hooks package.
+ * It provides the same functionality as dynamicImport.js but uses CommonJS syntax for compatibility.
+ * 
+ * WHY THIS FILE EXISTS:
+ * - The plugin-hooks package supports both CommonJS and ES module consumers
+ * - Node.js 18.x is strict about module syntax and throws "SyntaxError: Unexpected token 'export'"
+ *   when requiring ES module syntax in CommonJS contexts
+ * - SMS (Schema Management Service) and other CommonJS consumers need proper module.exports syntax
+ * - Modern applications using ES modules can use the dynamicImport.js version
+ * 
+ * @param {string} modulePath Module path to dynamically import.
+ * @returns {Promise<any>} Promise that resolves to the imported module.
+ */
+async function importFn(modulePath) {
+	return import(modulePath);
+}
+
+module.exports = importFn; 


### PR DESCRIPTION

Fix for failing build on node version 18

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.