### PR TITLE
Feature/cext 4829 context state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/plugin-hooks",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/plugin-hooks",
-  "version": "0.3.5-alpha.4",
+  "version": "0.3.5",
   "publishConfig": {
     "access": "public"
   },

--- a/src/afterAllExecutor.ts
+++ b/src/afterAllExecutor.ts
@@ -18,6 +18,7 @@ import type {
 	GraphQLData,
 	GraphQLError as GraphQLErrorType,
 	GraphQLResult,
+	StateApi,
 } from './types';
 import type { YogaLogger, GraphQLParams } from 'graphql-yoga';
 import { PLUGIN_HOOKS_ERROR_CODES } from './errorCodes';
@@ -28,10 +29,11 @@ export interface AfterAllExecutionContext {
 	body: unknown;
 	headers: Record<string, string>;
 	secrets: Record<string, string>;
+	state: StateApi;
+	logger: YogaLogger;
 	document: unknown;
 	result: { data?: GraphQLData; errors?: GraphQLErrorType[] };
 	setResultAndStopExecution: (result: GraphQLResult) => void;
-	logger: YogaLogger;
 	afterAll: HookConfig;
 }
 
@@ -45,17 +47,18 @@ export async function executeAfterAllHook(
 		body,
 		headers,
 		secrets,
+		state,
+		logger,
 		document,
 		result,
 		setResultAndStopExecution,
-		logger,
 		afterAll,
 	} = context;
 
 	try {
 		// Create payload with the execution result
 		const payload = {
-			context: { params, request, body, headers, secrets },
+			context: { params, request, body, headers, secrets, state, logger },
 			document,
 			result, // This is the GraphQL execution result
 		};

--- a/src/beforeAllExecutor.ts
+++ b/src/beforeAllExecutor.ts
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import { GraphQLError } from 'graphql/error';
 import getBeforeAllHookHandler, { UpdateContextFn } from './handleBeforeAllHooks';
-import type { HookConfig, MemoizedFns, GraphQLResult } from './types';
+import type { HookConfig, MemoizedFns, GraphQLResult, StateApi } from './types';
 import type { YogaLogger, GraphQLParams } from 'graphql-yoga';
 import { PLUGIN_HOOKS_ERROR_CODES } from './errorCodes';
 
@@ -22,6 +22,8 @@ export interface BeforeAllExecutionContext {
 	body: unknown;
 	headers: Record<string, string>;
 	secrets: Record<string, string>;
+	state: StateApi;
+	logger: YogaLogger;
 	document: unknown;
 	updateContext: UpdateContextFn;
 	setResultAndStopExecution: (result: GraphQLResult) => void;
@@ -37,6 +39,8 @@ export async function executeBeforeAllHook(
 		body,
 		headers,
 		secrets,
+		state,
+		logger,
 		document,
 		updateContext,
 		setResultAndStopExecution,
@@ -44,7 +48,7 @@ export async function executeBeforeAllHook(
 
 	try {
 		const payload = {
-			context: { params, request, body, headers, secrets },
+			context: { params, request, body, headers, secrets, state, logger },
 			document,
 		};
 		await beforeAllHookHandler({ payload, updateContext });

--- a/src/errorCodes.ts
+++ b/src/errorCodes.ts
@@ -18,6 +18,12 @@ export const PLUGIN_HOOKS_ERROR_CODES = {
 	/** Error during beforeAll hook execution */
 	ERROR_PLUGIN_HOOKS_BEFORE_ALL: 'ERROR_PLUGIN_HOOKS_BEFORE_ALL',
 
+	/** Error during beforeSource hook execution */
+	ERROR_PLUGIN_HOOKS_BEFORE_SOURCE: 'ERROR_PLUGIN_HOOKS_BEFORE_SOURCE',
+
+	/** Error during afterSource hook execution */
+	ERROR_PLUGIN_HOOKS_AFTER_SOURCE: 'ERROR_PLUGIN_HOOKS_AFTER_SOURCE',
+
 	/** Error during afterAll hook execution */
 	ERROR_PLUGIN_HOOKS_AFTER_ALL: 'ERROR_PLUGIN_HOOKS_AFTER_ALL',
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,17 +10,18 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { GraphQLError } from 'graphql/error';
 import { UpdateContextFn } from './handleBeforeAllHooks';
 import { createBeforeAllHookHandler, executeBeforeAllHook } from './beforeAllExecutor';
 import { createAfterAllHookHandler, executeAfterAllHook } from './afterAllExecutor';
-import type {
+import {
 	HookConfig,
 	MemoizedFns,
 	UserContext,
 	GraphQLData,
 	GraphQLError as GraphQLErrorType,
 	SourceHookConfig,
-	StateApi,
+	StateApi, PLUGIN_HOOKS_ERROR_CODES,
 } from './types';
 import getBeforeSourceHookHandler from './handleBeforeSourceHooks';
 import type { YogaLogger, Plugin, YogaInitialContext } from 'graphql-yoga';
@@ -210,22 +211,33 @@ export default async function hooksPlugin(config: PluginConfig): Promise<HooksPl
 						memoizedFns,
 					});
 
-					const payload = {
-						context: {
-							secrets: serverContext.secrets!,
-							state: serverContext.state!,
-							logger,
-						},
-						request: options,
-						operation: info.operation,
-						sourceName,
-					};
+					try {
+						const payload = {
+							context: {
+								secrets: serverContext.secrets!,
+								state: serverContext.state!,
+								logger,
+							},
+							request: options,
+							operation: info.operation,
+							sourceName,
+						};
 
-					await beforeSourceHookHandler({
-						payload,
-						hookType: 'beforeSource',
-						sourceName,
-					});
+						await beforeSourceHookHandler({
+							payload,
+							hookType: 'beforeSource',
+							sourceName,
+						});
+					} catch (err: unknown) {
+						throw new GraphQLError(
+							(err instanceof Error && err.message) || 'Error while executing beforeSource hook',
+							{
+								extensions: {
+									code: PLUGIN_HOOKS_ERROR_CODES.ERROR_PLUGIN_HOOKS_BEFORE_SOURCE,
+								},
+							},
+						);
+					}
 				}
 				return async ({
 					response,
@@ -240,23 +252,34 @@ export default async function hooksPlugin(config: PluginConfig): Promise<HooksPl
 						logger,
 						memoizedFns,
 					});
-					const payload = {
-						context: {
-							secrets: serverContext.secrets!,
-							state: serverContext.state!,
-							logger,
-						},
-						request: options,
-						operation: info.operation,
-						sourceName,
-						response,
-						setResponse,
-					};
-					await afterSourceHookHandler({
-						payload,
-						hookType: 'afterSource',
-						sourceName,
-					});
+					try {
+						const payload = {
+							context: {
+								secrets: serverContext.secrets!,
+								state: serverContext.state!,
+								logger,
+							},
+							request: options,
+							operation: info.operation,
+							sourceName,
+							response,
+							setResponse,
+						};
+						await afterSourceHookHandler({
+							payload,
+							hookType: 'afterSource',
+							sourceName,
+						});
+					} catch (err: unknown) {
+						throw new GraphQLError(
+							(err instanceof Error && err.message) || 'Error while executing afterSource hook',
+							{
+								extensions: {
+									code: PLUGIN_HOOKS_ERROR_CODES.ERROR_PLUGIN_HOOKS_AFTER_SOURCE,
+								},
+							},
+						);
+					}
 				};
 			},
 		};

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ import {
 	GraphQLData,
 	GraphQLError as GraphQLErrorType,
 	SourceHookConfig,
-	StateApi, PLUGIN_HOOKS_ERROR_CODES,
+	StateApi,
+	PLUGIN_HOOKS_ERROR_CODES,
 } from './types';
 import getBeforeSourceHookHandler from './handleBeforeSourceHooks';
 import type { YogaLogger, Plugin, YogaInitialContext } from 'graphql-yoga';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import type {
 	GraphQLData,
 	GraphQLError as GraphQLErrorType,
 	SourceHookConfig,
+	StateApi,
 } from './types';
 import getBeforeSourceHookHandler from './handleBeforeSourceHooks';
 import type { YogaLogger, Plugin, YogaInitialContext } from 'graphql-yoga';
@@ -80,6 +81,9 @@ export default async function hooksPlugin(config: PluginConfig): Promise<HooksPl
 	try {
 		const { beforeAll, afterAll, beforeSource, afterSource, baseDir, logger } = config;
 
+		// Unchanging server context
+		const serverContext: Partial<UserContext> = {};
+
 		// Check if any hooks are configured
 		const hasAnyHooks = beforeAll || afterAll || beforeSource || afterSource;
 		if (!hasAnyHooks) {
@@ -88,6 +92,7 @@ export default async function hooksPlugin(config: PluginConfig): Promise<HooksPl
 				onFetch: async () => {},
 			};
 		}
+
 		const memoizedFns: MemoizedFns = {
 			afterSource: {},
 			beforeSource: {},
@@ -105,6 +110,9 @@ export default async function hooksPlugin(config: PluginConfig): Promise<HooksPl
 				const { params, request } = context || {};
 				const headers = Object.fromEntries(request.headers.entries());
 				const secrets = ('secrets' in context ? context.secrets : {}) as Record<string, string>;
+				const state = ('state' in context ? context.state : {}) as StateApi;
+				serverContext.secrets = secrets;
+				serverContext.state = state;
 				let body = {};
 				if (request && request.body) {
 					body = request.body;
@@ -143,6 +151,8 @@ export default async function hooksPlugin(config: PluginConfig): Promise<HooksPl
 							body,
 							headers,
 							secrets,
+							state,
+							logger,
 							document,
 							updateContext,
 							setResultAndStopExecution,
@@ -166,10 +176,11 @@ export default async function hooksPlugin(config: PluginConfig): Promise<HooksPl
 								body,
 								headers,
 								secrets,
+								state,
+								logger,
 								document,
 								result,
 								setResultAndStopExecution,
-								logger,
 								afterAll: afterAll!,
 							});
 						},
@@ -200,6 +211,11 @@ export default async function hooksPlugin(config: PluginConfig): Promise<HooksPl
 					});
 
 					const payload = {
+						context: {
+							secrets: serverContext.secrets!,
+							state: serverContext.state!,
+							logger,
+						},
 						request: options,
 						operation: info.operation,
 						sourceName,
@@ -225,6 +241,11 @@ export default async function hooksPlugin(config: PluginConfig): Promise<HooksPl
 						memoizedFns,
 					});
 					const payload = {
+						context: {
+							secrets: serverContext.secrets!,
+							state: serverContext.state!,
+							logger,
+						},
 						request: options,
 						operation: info.operation,
 						sourceName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,9 +26,35 @@ export type GraphQLResult = {
 	errors?: GraphQLError[];
 };
 
+/**
+ * State API interface for managing key-value pairs.
+ */
+export interface StateApi {
+	/**
+	 * Get a value by key.
+	 * @param key Key to retrieve.
+	 */
+	get(key: string): Promise<string | null>;
+
+	/**
+	 * Put a key-value pair with optional TTL.
+	 * @param key Key to store.
+	 * @param value Value to store.
+	 * @param config Optional configuration object that may contain a TTL value in seconds.
+	 */
+	put(key: string, value: string, config?: { ttl?: number }): Promise<void>;
+
+	/**
+	 * Delete a key-value pair.
+	 * @param key
+	 */
+	delete(key: string): Promise<void>;
+}
+
 export interface UserContext extends YogaInitialContext {
 	headers?: Record<string, string>;
 	secrets?: Record<string, string>;
+	state?: StateApi;
 }
 
 export type SourceHookConfig = Record<string, HookConfig[]>;
@@ -72,6 +98,7 @@ export interface PayloadContext {
 	body: unknown;
 	headers?: Record<string, string>;
 	secrets?: Record<string, string>;
+	state?: StateApi;
 }
 
 export type HookFunction = (

--- a/src/utils/hookResolver.ts
+++ b/src/utils/hookResolver.ts
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import type { YogaLogger } from 'graphql-yoga';
 import type { OperationDefinitionNode } from 'graphql';
-import type { HookConfig, HookFunction, MemoizedFns } from '../types';
+import type { HookConfig, HookFunction, MemoizedFns, StateApi } from '../types';
 //@ts-expect-error The dynamic import is a workaround for cjs
 import importFn from '../dynamicImport';
 import {
@@ -34,12 +34,22 @@ export interface HookResolverConfig {
 	memoizedFns: MemoizedFns;
 }
 export interface BeforeSourceHookPayload {
+	context: {
+		logger: YogaLogger;
+		secrets: Record<string, string>;
+		state: StateApi;
+	};
 	sourceName: string;
 	request: RequestInit;
 	operation: OperationDefinitionNode;
 }
 
 export interface AfterSourceHookPayload {
+	context: {
+		logger: YogaLogger;
+		secrets: Record<string, string>;
+		state: StateApi;
+	};
 	sourceName: string;
 	request: RequestInit;
 	operation: OperationDefinitionNode;
@@ -67,6 +77,46 @@ export interface SourceHookExecConfig {
 	sourceName: string;
 }
 
+async function getHookFunction(
+	config: HookResolverConfig | SourceHookResolverConfig,
+	hookConfig: HookConfig,
+) {
+	const { baseDir, logger } = config;
+	let hookFunction: HookFunction | undefined;
+
+	// Resolve function based on configuration type
+	if (isRemoteFn(hookConfig.composer || '')) {
+		// Remote endpoint function
+		logger.debug('Invoking remote function %s', hookConfig.composer);
+		hookFunction = await getWrappedRemoteHookFunction(hookConfig.composer!, {
+			baseDir,
+			importFn,
+			logger,
+			blocking: hookConfig.blocking,
+		});
+	} else if (isModuleFn(hookConfig)) {
+		// Module function (bundled scenarios)
+		logger.debug('Invoking local module function %s %s', hookConfig.module, hookConfig.fn);
+		hookFunction = await getWrappedLocalModuleHookFunction(hookConfig.module!, hookConfig.fn!, {
+			baseDir,
+			importFn,
+			logger,
+			blocking: hookConfig.blocking,
+		});
+	} else {
+		// Local function at runtime
+		logger.debug('Invoking local function %s', hookConfig.composer);
+		hookFunction = await getWrappedLocalHookFunction(hookConfig.composer!, {
+			baseDir,
+			importFn,
+			logger,
+			blocking: hookConfig.blocking,
+		});
+	}
+
+	return hookFunction;
+}
+
 /**
  * Resolves and memoizes hook functions with consistent logic for both beforeAll and afterAll hooks
  *
@@ -87,7 +137,7 @@ export interface SourceHookExecConfig {
 export async function resolveHookFunction(
 	config: HookResolverConfig,
 ): Promise<HookFunction | undefined> {
-	const { hookConfig, hookType, baseDir, logger, memoizedFns } = config;
+	const { hookConfig, hookType, memoizedFns } = config;
 
 	// Check if function is already memoized
 	const memoizedFn = memoizedFns[hookType];
@@ -95,37 +145,7 @@ export async function resolveHookFunction(
 		return memoizedFn;
 	}
 
-	let hookFunction: HookFunction | undefined;
-
-	// Resolve function based on configuration type
-	if (isRemoteFn(hookConfig.composer || '')) {
-		// Remote endpoint function
-		logger.debug('Invoking remote function %s', hookConfig.composer);
-		hookFunction = await getWrappedRemoteHookFunction(hookConfig.composer!, {
-			baseDir,
-			importFn,
-			logger,
-			blocking: hookConfig.blocking,
-		});
-	} else if (isModuleFn(hookConfig)) {
-		// Module function (bundled scenarios)
-		logger.debug('Invoking local module function %s %s', hookConfig.module, hookConfig.fn);
-		hookFunction = await getWrappedLocalModuleHookFunction(hookConfig.module!, hookConfig.fn!, {
-			baseDir,
-			importFn,
-			logger,
-			blocking: hookConfig.blocking,
-		});
-	} else {
-		// Local function at runtime
-		logger.debug('Invoking local function %s', hookConfig.composer);
-		hookFunction = await getWrappedLocalHookFunction(hookConfig.composer!, {
-			baseDir,
-			importFn,
-			logger,
-			blocking: hookConfig.blocking,
-		});
-	}
+	const hookFunction: HookFunction | undefined = await getHookFunction(config, hookConfig);
 
 	// Memoize the resolved function
 	if (hookFunction) {
@@ -141,6 +161,7 @@ export async function resolveHookFunction(
  * @param hookConfig - The hook configuration
  * @param index - The index of the hook in the array
  * @param config - Configuration object containing dependencies
+ * @param sourceName - The name of the source for which the hook is being resolved
  * @returns Promise<HookFunction | undefined> - The resolved hook function or undefined
  */
 export async function resolveSourceHookFunction(
@@ -149,7 +170,7 @@ export async function resolveSourceHookFunction(
 	config: SourceHookResolverConfig,
 	sourceName: string,
 ): Promise<HookFunction | undefined> {
-	const { hookType, baseDir, logger, memoizedFns } = config;
+	const { hookType, memoizedFns } = config;
 
 	// Check if function is already memoized
 	if (
@@ -160,37 +181,7 @@ export async function resolveSourceHookFunction(
 		return memoizedFns[hookType][sourceName][index] as HookFunction;
 	}
 
-	let hookFunction: HookFunction | undefined;
-
-	// Resolve function based on configuration type
-	if (isRemoteFn(hookConfig.composer || '')) {
-		// Remote endpoint function
-		logger.debug('Invoking remote function %s', hookConfig.composer);
-		hookFunction = await getWrappedRemoteHookFunction(hookConfig.composer!, {
-			baseDir,
-			importFn,
-			logger,
-			blocking: hookConfig.blocking,
-		});
-	} else if (isModuleFn(hookConfig)) {
-		// Module function (bundled scenarios)
-		logger.debug('Invoking local module function %s %s', hookConfig.module, hookConfig.fn);
-		hookFunction = await getWrappedLocalModuleHookFunction(hookConfig.module!, hookConfig.fn!, {
-			baseDir,
-			importFn,
-			logger,
-			blocking: hookConfig.blocking,
-		});
-	} else {
-		// Local function at runtime
-		logger.debug('Invoking local function %s', hookConfig.composer);
-		hookFunction = await getWrappedLocalHookFunction(hookConfig.composer!, {
-			baseDir,
-			importFn,
-			logger,
-			blocking: hookConfig.blocking,
-		});
-	}
+	const hookFunction: HookFunction | undefined = await getHookFunction(config, hookConfig);
 
 	// Memoize the resolved function
 	if (hookFunction) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

New context state feature needs to be available in context within hooks. Added context state, secrets, and logger to all hooks (beforeAll, beforeSource, afterSource, afterAll) with a common signature for ease of use.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/CEXT-4829

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.